### PR TITLE
add babel-runtime dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test": "mocha test --require babel-core/register"
   },
   "dependencies": {
+    "babel-runtime": "^6.9.2",
     "bluebird": "^3.1.1",
     "lodash.defaults": "^4.0.0",
     "lodash.difference": "^4.0.1",


### PR DESCRIPTION
Resolves babel-runtime not found in @next npm package

```
Error: Cannot find module 'babel-runtime/regenerator'
    at Function.Module._resolveFilename (module.js:440:15)
    at Function.Module._load (module.js:388:25)
    at Module.require (module.js:468:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/home/phil/git-repos/personal/personal-home2/node_modules/koa-nunjucks-2/compiled.js:3:20)
```

commit e0b7a1b828664b0145c7c9ae4aa6a4f5c3417622 needed to add this dependency.
